### PR TITLE
refactor(test): replace sdkman install w/ action-setup-tools

### DIFF
--- a/test/action.yaml
+++ b/test/action.yaml
@@ -20,9 +20,8 @@ runs:
     - name: Checkout
       uses: actions/checkout@v3
       if: inputs.checkout-repo
-    - name: Sdkman
-      shell: bash
-      run: sdk env install
+    - name: Setup tools
+      uses: open-turo/action-setup-tools@v1
     - name: Test
       env:
         JAVA_HOME: ${{ env.JAVA_HOME }}


### PR DESCRIPTION
## changes
- Replaces `sdk env install` step in the `lint` action with the https://github.com/open-turo/action-setup-tools action

In particular, this will now install `sdk env install` if users specify `.sdkmanrc` in the repo