### PR TITLE
feat(lint): add artifactoryUsername and artifactoryAuthToken inputs

### DIFF
--- a/lint/README.md
+++ b/lint/README.md
@@ -16,10 +16,12 @@ jobs:
 
 ## Inputs
 
-| parameter     | description                                                                | required | default |
-| ------------- | -------------------------------------------------------------------------- | -------- | ------- |
-| checkout-repo | Perform checkout as first step of action                                   | `false`  | true    |
-| github-token  | GitHub token that can checkout the repository. e.g. 'secrets.GITHUB_TOKEN' | `true`   |         |
+| parameter              | description                                                                | required | default |
+| ---------------------- | -------------------------------------------------------------------------- | -------- | ------- |
+| checkout-repo          | Perform checkout as first step of action                                   | `false`  | true    |
+| github-token           | GitHub token that can checkout the repository. e.g. 'secrets.GITHUB_TOKEN' | `true`   |         |
+| artifactory-username   | Username to use for Artifactory access                                     | `true`   |         |
+| artifactory-auth-token | Authentication token to use with username for Artifactory access           | `true`   |         |
 
 ## Runs
 

--- a/lint/action.yaml
+++ b/lint/action.yaml
@@ -22,6 +22,6 @@ runs:
       with:
         fetch-depth: 0
     - uses: open-turo/action-pre-commit@v1
-    - if: hashFiles('script/lint') != ''
-      shell: bash
-      run: script/lint
+      env:
+        ORG_GRADLE_PROJECT_artifactoryUsername: ${{ inputs.artifactory-username }}
+        ORG_GRADLE_PROJECT_artifactoryAuthToken: ${{ inputs.artifactory-auth-token }}

--- a/lint/action.yaml
+++ b/lint/action.yaml
@@ -8,6 +8,12 @@ inputs:
   github-token:
     required: true
     description: GitHub token that can checkout the repository. e.g. 'secrets.GITHUB_TOKEN'
+  artifactory-username:
+    required: true
+    description: Username to use for Artifactory access
+  artifactory-auth-token:
+    required: true
+    description: Authentication token to use with username for Artifactory access
 runs:
   using: composite
   steps:


### PR DESCRIPTION
## background
In current test action, Turo runs `./gradlew <action>`. In doing so, this often involves reading in artifactory credentials. However, this action doesn't have this information and needs the additional inputs from the user

## changes
- Add input parameters to the action for artifactory credentials
