### PR TITLE
[Release] Add step for setting up tools

### DIFF
--- a/release/action.yaml
+++ b/release/action.yaml
@@ -33,6 +33,8 @@ runs:
       if: inputs.checkout-repo
       with:
         fetch-depth: 0
+    - name: Setup tools
+      uses: open-turo/action-setup-tools@v1
     - name: Release
       uses: cycjimmy/semantic-release-action@v3
       with:


### PR DESCRIPTION
## background

The current release action is a bit lacking because we can't utilize the semantic-release-action without setting up the tools.
However, setting up the tools requires checking out the repo so that we can read the environment / tools.

## changes
- Adds a setup tools step before starting the semantic-release-action and after checking out the repo.
