### PR TITLE
fix(release): pass in github-token to authorize push permissions in local git

### DIFF
--- a/release/action.yaml
+++ b/release/action.yaml
@@ -33,6 +33,7 @@ runs:
       if: inputs.checkout-repo
       with:
         fetch-depth: 0
+        token: ${{ inputs.github-token }}
     - name: Setup tools
       uses: open-turo/action-setup-tools@v1
     - name: Release


### PR DESCRIPTION
## background
This attempts to fix an issue where publishing a release that needs to modify a file in the repo does not have permissions. Copying solution from https://github.com/semantic-release/github/issues/175#issuecomment-1122569317 This assumes that the github token passed in is from a user that has admin permissions

## changes
- pass in github token to the checkout repo
