### PR TITLE
fix: do not need to explicitly test for true

### DIFF
--- a/lint/action.yaml
+++ b/lint/action.yaml
@@ -17,11 +17,13 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v3
-      if: inputs.checkout-repo == 'true'
+    - name: Checkout
+      uses: actions/checkout@v3
+      if: inputs.checkout-repo
       with:
         fetch-depth: 0
-    - uses: open-turo/action-pre-commit@v1
+    - Name: Pre-commit
+      uses: open-turo/action-pre-commit@v1
       env:
         ORG_GRADLE_PROJECT_artifactoryUsername: ${{ inputs.artifactory-username }}
         ORG_GRADLE_PROJECT_artifactoryAuthToken: ${{ inputs.artifactory-auth-token }}

--- a/release/action.yaml
+++ b/release/action.yaml
@@ -30,7 +30,7 @@ runs:
   steps:
     - name: Checkout
       uses: actions/checkout@v3
-      if: inputs.checkout-repo == 'true'
+      if: inputs.checkout-repo
       with:
         fetch-depth: 0
     - name: Setup tools

--- a/test/action.yaml
+++ b/test/action.yaml
@@ -19,7 +19,7 @@ runs:
   steps:
     - name: Checkout
       uses: actions/checkout@v3
-      if: inputs.checkout-repo == 'true'
+      if: inputs.checkout-repo
     - name: Setup tools
       uses: open-turo/action-setup-tools@v1
     - name: Test


### PR DESCRIPTION
`if: inputs.val == 'true'` is the same as `if: inputs.val` so lets use the simpler form throughout all of `open-turo` repos.