### PR TITLE
fix(release): don't persist credentials when checking out the repo

### DIFF
--- a/release/action.yaml
+++ b/release/action.yaml
@@ -33,6 +33,7 @@ runs:
       if: inputs.checkout-repo
       with:
         fetch-depth: 0
+        persist-credentials: false
     - name: Setup tools
       uses: open-turo/action-setup-tools@v1
     - name: Release


### PR DESCRIPTION

**Description**

To allow semantic release to use the passed github token to use git

**Changes**

* fix(release): don't persist credentials when checking out the repo

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
