### PR TITLE
fix(release): default extra-plugins to open-turo/semantic-release-config

### DIFF
--- a/release/action.yaml
+++ b/release/action.yaml
@@ -14,7 +14,9 @@ inputs:
     default: "false"
   extra-plugins:
     required: false
-    description: Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.
+    description: Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.  Defaults to install @open-turo/semantic-release-config.
+    default: |
+      @open-turo/semantic-release-config@^1.4.0
 outputs:
   new-release-published:
     description: Whether a new release was published


### PR DESCRIPTION

**Description**

This updates the extra-plugins to default to `@open-turo/semantic-release-config@^1.4.0`.  This will
allow us to stop needing to configure it everywhere.



**Changes**

* fix(release): default extra-plugins to open-turo/semantic-release-config

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
