### PR TITLE
fix(lint): inputs.checkout-repo string comparison

### DIFF
--- a/lint/action.yaml
+++ b/lint/action.yaml
@@ -19,7 +19,7 @@ runs:
   steps:
     - name: Checkout
       uses: actions/checkout@v4
-      if: inputs.checkout-repo
+      if: inputs.checkout-repo == 'true'
       with:
         fetch-depth: 0
     - name: Pre-commit


### PR DESCRIPTION
`inputs.checkout-repo` is a string and not a boolean, passing in false to the action right now has no effect as 
`if: inputs.checkout-repo` doesn't evaluate to false. 

Fixing this by updating the condition check to `if: inputs.checkout-repo == 'true'` 