### PR TITLE
feat(test): input for gradle test task

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -28,6 +28,18 @@ jobs:
           gradlew-args: --debug
 ```
 
+### Running specific test task
+
+```yaml
+jobs:
+  test:
+    steps:
+      - name: Test
+        uses: open-turo/actions-jvm/test@v1
+        with:
+          gradle-task: integrationTest
+```
+
 ## Inputs
 
 | parameter              | description                                                                     | required | default |
@@ -36,6 +48,7 @@ jobs:
 | github-token           | GitHub token that can checkout the repository. e.g. 'secrets.GITHUB_TOKEN'      | `true`   |         |
 | artifactory-username   | Username to use for Artifactory access                                          | `true`   |         |
 | artifactory-auth-token | Authentication token to use with username for Artifactory access                | `true`   |         |
+| gradle-task            | An optional string for the gradle test task to run. e.g. "integrationTest"      | `false`  | `test`  |
 | gradlew-args           | An optional string of command line arguments to pass to gradlew. e.g. "--debug" | `false`  |         |
 
 ## Runs

--- a/test/action.yaml
+++ b/test/action.yaml
@@ -14,6 +14,10 @@ inputs:
   artifactory-auth-token:
     required: true
     description: Authentication token to use with username for Artifactory access
+  gradle-task:
+    required: false
+    description: An optional string for the gradle test task to run. e.g. "integrationTest"
+    default: "test"
   gradlew-args:
     required: false
     description: An optional string of command line arguments to pass to gradlew. e.g. "--debug"
@@ -34,4 +38,4 @@ runs:
         sdk current
         sdk env
         sdk current
-        ./gradlew test -PartifactoryUsername=${{ inputs.artifactory-username }} -PartifactoryAuthToken=${{ inputs.artifactory-auth-token }} ${{ inputs.gradlew-args }}
+        ./gradlew ${{ inputs.gradle-task }} -PartifactoryUsername=${{ inputs.artifactory-username }} -PartifactoryAuthToken=${{ inputs.artifactory-auth-token }} ${{ inputs.gradlew-args }}


### PR DESCRIPTION
In this PR, update test action to take in a gradle task input to run non-unit test tasks like integrationTest. 

The default for this input remains "test" task, there should be no changes to existing usage of this action. 