### PR TITLE
fix: input.checkout-repo == 'true'

### DIFF
--- a/release/action.yaml
+++ b/release/action.yaml
@@ -32,7 +32,7 @@ runs:
   steps:
     - name: Checkout
       uses: actions/checkout@v4
-      if: inputs.checkout-repo
+      if: inputs.checkout-repo == 'true'
       with:
         fetch-depth: 0
         persist-credentials: false

--- a/test/action.yaml
+++ b/test/action.yaml
@@ -27,7 +27,7 @@ runs:
   steps:
     - name: Checkout
       uses: actions/checkout@v4
-      if: inputs.checkout-repo
+      if: inputs.checkout-repo == 'true'
     - name: Setup tools
       uses: open-turo/action-setup-tools@v1
     - name: Test


### PR DESCRIPTION
Existing check `if: inputs.checkout-repo` doesn't really do anything. 

Updating for string equality check like `if: inputs.checkout-repo == 'true'` 