### PR TITLE
feat: allow prerelease & lint-release-notes to run on pull request trigger

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,3 +21,10 @@ repos:
     rev: v1.6.26
     hooks:
       - id: actionlint
+  - repo: local
+    hooks:
+      - id: update-action-readme
+        name: update-action-readme
+        entry: ./script/update-action-readme
+        language: script
+        files: '.*/action\.yaml$'

--- a/build-docker/README.md
+++ b/build-docker/README.md
@@ -1,6 +1,12 @@
 # GitHub Action Release
 
-GitHub Action for [Semantic Release][semantic-url].
+<!-- prettier-ignore-start -->
+<!-- action-docs-description -->
+## Description
+
+Builds and push docker images for the input platform, tags and image version
+<!-- action-docs-description -->
+<!-- prettier-ignore-end -->
 
 ## Usage
 
@@ -49,26 +55,41 @@ steps:
 **IMPORTANT** : `GITHUB_TOKEN` does not have the required permissions to operate on protected branches.
 If you are using this action for protected branches, replace `GITHUB_TOKEN` with [Personal Access Token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line). If using the `@semantic-release/git` plugin for protected branches, avoid persisting credentials as part of `actions/checkout@v4` by setting the parameter `persist-credentials: false`. This credential does not have the required permission to operate on protected branches.
 
-### Inputs
+<!-- prettier-ignore-start -->
+<!-- action-docs-inputs -->
+## Inputs
 
-|    Input Parameter     | Required | Description                                                                                                      | Default               |
-| :--------------------: | -------- | ---------------------------------------------------------------------------------------------------------------- | --------------------- |
-|   docker-config-file   | false    | Whether or not to checkout the repo as the first step                                                            | `.docker-config.json` |
-|     dockerhub-user     | true     | username for dockerhub                                                                                           |                       |
-|   dockerhub-password   | true     | password for dockerhub                                                                                           |                       |
-|      github-token      | true     | Path to the docker config file (defaults to .docker-config.json) Must contain imageName, may contain dockerfile. |                       |
-|  artifactory-username  | true     | Artifactory user name usually secrets.ARTIFACTORY_USERNAME                                                       |                       |
-| artifactory-auth-token | true     | Artifactory auth token usually secrets.ARTIFACTORY_PASSWORD                                                      |                       |
-|     image-version      | true     | Docker image version                                                                                             |                       |
-|     image-platform     | false    | Target platform to build image for (eg. linux/amd64 (default), linux/arm64, etc)                                 | linux/amd64           |
-|  docker-metadata-tags  | false    | 'List of tags as key-value pair attributes' See: https://github.com/docker/metadata-action#tags-input            | linux/amd64           |
+| parameter | description | required | default |
+| --- | --- | --- | --- |
+| docker-config-file | Path to the docker config file (defaults to .docker-config.json) Must contain imageName, may contain dockerfile. | `false` | .docker-config.json |
+| dockerhub-user | username for dockerhub | `true` |  |
+| dockerhub-password | password for dockerhub | `true` |  |
+| github-token | Usually secrets.GITHUB_TOKEN | `true` |  |
+| artifactory-username | Artifactory user name usually secrets.ARTIFACTORY_USERNAME | `true` |  |
+| artifactory-auth-token | Artifactory auth token usually secrets.ARTIFACTORY_AUTH_TOKEN | `true` |  |
+| image-version | Docker image version | `true` |  |
+| image-platform | Target platform to build image for (eg. linux/amd64 (default), linux/arm64, etc) | `false` | linux/amd64 |
+| docker-metadata-tags | 'List of tags as key-value pair attributes' See: https://github.com/docker/metadata-action#tags-input | `false` |  |
+<!-- action-docs-inputs -->
 
-### Outputs
+<!-- action-docs-outputs -->
+## Outputs
 
-| Output Parameter | Description                                        |
-| :--------------: | -------------------------------------------------- |
-|    image-name    | Docker image name                                  |
-|  image-with-tag  | Full image with tag - <image-name>:<image-version> |
+| parameter | description |
+| --- | --- |
+| image-name | Docker image name |
+| image-with-tag | Full image with tag - <image-name>:<image-version> |
+<!-- action-docs-outputs -->
+
+<!-- action-docs-runs -->
+## Runs
+
+This action is a `composite` action.
+<!-- action-docs-runs -->
+
+<!-- action-docs-usage  -->
+<!-- action-docs-usage -->
+<!-- prettier-ignore-end -->
 
 #### Using Output Variables:
 

--- a/lint/README.md
+++ b/lint/README.md
@@ -1,8 +1,12 @@
 # GitHub Action Lint
 
+<!-- prettier-ignore-start -->
+<!-- action-docs-description -->
 ## Description
 
 GitHub Action to lint a JVM based repository
+<!-- action-docs-description -->
+<!-- prettier-ignore-end -->
 
 ## Usage
 
@@ -13,19 +17,6 @@ jobs:
       - name: Action lint
         uses: open-turo/actions-jvm/lint@v1
 ```
-
-## Inputs
-
-| parameter              | description                                                                | required | default |
-| ---------------------- | -------------------------------------------------------------------------- | -------- | ------- |
-| checkout-repo          | Perform checkout as first step of action                                   | `false`  | true    |
-| github-token           | GitHub token that can checkout the repository. e.g. 'secrets.GITHUB_TOKEN' | `true`   |         |
-| artifactory-username   | Username to use for Artifactory access                                     | `true`   |         |
-| artifactory-auth-token | Authentication token to use with username for Artifactory access           | `true`   |         |
-
-## Runs
-
-This action is an `composite` action.
 
 ## Lint Checks
 
@@ -38,3 +29,29 @@ This action runs the following lint checks:
 
 - By default, this action will perform actions/checkout as its first step.
 - This expects that `.commitlintrc.yaml` will be present to enforce [`conventional-commit`](https://github.com/wagoid/commitlint-github-action).
+
+<!-- prettier-ignore-start -->
+<!-- action-docs-inputs -->
+## Inputs
+
+| parameter | description | required | default |
+| --- | --- | --- | --- |
+| checkout-repo | Perform checkout as first step of action | `false` | true |
+| github-token | GitHub token that can checkout the repository. e.g. 'secrets.GITHUB_TOKEN' | `true` |  |
+| artifactory-username | Username to use for Artifactory access | `true` |  |
+| artifactory-auth-token | Authentication token to use with username for Artifactory access | `true` |  |
+<!-- action-docs-inputs -->
+
+<!-- action-docs-outputs -->
+
+<!-- action-docs-outputs -->
+
+<!-- action-docs-runs -->
+## Runs
+
+This action is a `composite` action.
+<!-- action-docs-runs -->
+
+<!-- action-docs-usage  -->
+<!-- action-docs-usage -->
+<!-- prettier-ignore-end -->

--- a/lint/action.yaml
+++ b/lint/action.yaml
@@ -27,3 +27,11 @@ runs:
       env:
         ORG_GRADLE_PROJECT_artifactoryUsername: ${{ inputs.artifactory-username }}
         ORG_GRADLE_PROJECT_artifactoryAuthToken: ${{ inputs.artifactory-auth-token }}
+    - uses: open-turo/actions-release/lint-release-notes@v4
+      if: github.event_name == 'pull_request'
+      with:
+        github-token: ${{ inputs.github-token }}
+        checkout-repo: true
+      env:
+        ORG_GRADLE_PROJECT_artifactoryUsername: ${{ inputs.artifactory-auth-token }}
+        ORG_GRADLE_PROJECT_artifactoryAuthToken: ${{ inputs.artifactory-auth-token }}

--- a/prerelease-msvc/README.md
+++ b/prerelease-msvc/README.md
@@ -1,10 +1,12 @@
 # GitHub Action: Prerelease Microservice
 
+<!-- prettier-ignore-start -->
+<!-- action-docs-description -->
 ## Description
 
-GitHub Action to compute a prerelease version based on the latest release version and the number of commits since the
-latest release. This will also generate a docker tag based on the computed version if the label `prerelease` is
-specified on the PR.
+< GitHub Action to compute a prerelease version based on the latest release version and the number of commits since the latest release. This will also generate a docker tag based on the computed version if the label `prerelease` is specified on the PR.
+<!-- action-docs-description -->
+<!-- prettier-ignore-end -->
 
 ## Configuration
 
@@ -31,26 +33,46 @@ If using the `@semantic-release/git` plugin for protected branches, avoid persis
 of `actions/checkout@v4` by setting the parameter `persist-credentials: false`. This credential does not have the
 required permission to operate on protected branches.
 
+<!-- prettier-ignore-start -->
+<!-- action-docs-inputs -->
 ## Inputs
 
-| parameter         | description                                                                                                           | required | default |
-| ----------------- | --------------------------------------------------------------------------------------------------------------------- | -------- | ------- |
-| checkout-repo     | Perform checkout as first step of action                                                                              | `false`  | true    |
-| create-prerelease | Whether semantic-release should create a prerelease or do a dry run                                                   | `false`  | false   |
-| github-token      | GitHub token that can checkout the repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN' | `true`   |         |
-| extra-plugins     | Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.     | `false`  |         |
+| parameter | description | required | default |
+| --- | --- | --- | --- |
+| checkout-repo | Perform checkout as first step of action | `false` | true |
+| create-prerelease | Whether semantic-release should create a prerelease or do a dry run. This can be useful to set to true when a prerelease requires pushing artifacts semantic-release is in charge of generating | `false` | false |
+| docker-config-file | Path to the docker config file (defaults to .docker-config.json) Must contain imageName, may contain dockerfile. | `false` | .docker-config.json |
+| dockerhub-user | username for dockerhub | `true` |  |
+| dockerhub-password | password for dockerhub | `true` |  |
+| github-token | GitHub token that can checkout the repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN' | `true` |  |
+| extra-plugins | Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.  Defaults to install @open-turo/semantic-release-config. | `false` | @open-turo/semantic-release-config  |
+| artifactory-username | Artifactory user name usually secrets.ARTIFACTORY_USERNAME | `true` |  |
+| artifactory-auth-token | Artifactory auth token usually secrets.ARTIFACTORY_AUTH_TOKEN | `true` |  |
+<!-- action-docs-inputs -->
 
+<!-- action-docs-outputs -->
 ## Outputs
 
-| parameter                 | description                         |
-| ------------------------- | ----------------------------------- |
-| new-release-published     | Whether a new release was published |
-| new-release-version       | Version of the new release          |
-| new-release-major-version | Major version of the new release    |
+| parameter | description |
+| --- | --- |
+| new-release-published | Whether a new release was published |
+| new-release-version | Version of the new release |
+| new-release-major-version | Major version of the new release |
+| image-name | Docker image name |
+| image-with-tag | Full image with tag - <image-name>:<image-version> |
+| pull-request-number | Pull request number |
+| run-url | URL to the GHA run |
+<!-- action-docs-outputs -->
 
+<!-- action-docs-runs -->
 ## Runs
 
-This action is an `composite` action.
+This action is a `composite` action.
+<!-- action-docs-runs -->
+
+<!-- action-docs-usage  -->
+<!-- action-docs-usage -->
+<!-- prettier-ignore-end -->
 
 ## Additional Examples
 

--- a/prerelease-msvc/action.yaml
+++ b/prerelease-msvc/action.yaml
@@ -156,7 +156,7 @@ runs:
         dry-run: ${{ inputs.create-prerelease == 'false' }}
         extra-plugins: ${{ inputs.extra-plugins }}
         override-github-ref-name: ${{ steps.source-vars.outputs.branch }}
-        override-github-sha: ${{ steps.source-vars.outputs.sha }}  
+        override-github-sha: ${{ steps.source-vars.outputs.sha }}
 
     - id: vars
       if: steps.check-pr.outputs.has_prerelease_label == 'true'

--- a/prerelease-msvc/action.yaml
+++ b/prerelease-msvc/action.yaml
@@ -62,20 +62,66 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Dump GitHub context
+      env:
+        GITHUB_CONTEXT: ${{ toJSON(github) }}
+      shell: bash
+      run: |
+        echo "::group::Github Context"
+        echo "$GITHUB_CONTEXT"
+        echo "::endgroup::"
+
+    - name: Dump environment
+      shell: bash
+      run: |
+        echo "::group::bash_env"
+        set
+        echo "::endgroup::"
+
+    - name: Set vars
+      id: source-vars
+      shell: bash
+      env:
+        event_name: ${{ github.event_name }}
+        dispatch_client_payload_ref: ${{ github.event.client_payload.ref }}
+        dispatch_client_payload_sha: ${{ github.event.client_payload.sha }}
+        push_ref_name: ${{ github.ref_name }}
+        push_sha: ${{ github.sha }}
+        pull_request_ref_name: ${{ github.event.pull_request.head.ref }}
+        pull_request_sha: ${{ github.event.pull_request.head.sha }}
+      run: |
+        echo "event_name=$event_name"
+
+        if [ "$event_name" == "push" ]; then
+          branch=$push_ref_name
+          sha=$push_sha
+        elif [ "$event_name" == "repository_dispatch" ]; then
+          branch=$dispatch_client_payload_ref
+          sha=$dispatch_client_payload_sha
+        elif [ "$event_name" == "pull_request" ]; then
+          branch=$pull_request_ref_name
+          sha=$pull_request_sha
+        else
+          echo "::error::Unsupported event type '$event_name'"
+          exit 1
+        fi
+
+        echo "branch=$branch"
+        echo "branch=$branch" >> $GITHUB_OUTPUT
+
+        echo "sha=$sha"
+        echo "sha=$sha" >> $GITHUB_OUTPUT
+
     - uses: actions/checkout@v4
-      if: inputs.checkout-repo == 'true' && github.event_name == 'push'
       with:
         fetch-depth: 0
-        ref: ${{ github.base_ref }}
-    - uses: actions/checkout@v4
-      if: inputs.checkout-repo == 'true' && github.event_name == 'repository_dispatch'
-      with:
-        fetch-depth: 0
-        ref: ${{ github.event.client_payload.ref }}
+        ref: ${{ steps.source-vars.outputs.branch }}
 
     # Find PR
     - uses: 8BitJonny/gh-get-current-pr@2.2.0
       id: PR
+      with:
+        sha: ${{ steps.source-vars.outputs.sha }}
 
     - id: check-pr
       shell: bash
@@ -87,17 +133,18 @@ runs:
           echo "pr_found=true" >> $GITHUB_OUTPUT
           echo "has_prerelease_label=${{ contains(toJSON(fromJSON(steps.PR.outputs.pr).labels.*.name), 'prerelease') }}" >> $GITHUB_OUTPUT
         fi
+        git branch
+        echo "branch: ${{ steps.source-vars.outputs.branch }}"
 
     - if: steps.check-pr.outputs.pr_found != 'true'
       shell: bash
-      run: echo "PR does not exist for branch (${{ github.ref_name }}) - ignoring"
+      run: echo "PR does not exist for branch (${{ steps.source-vars.outputs.branch }}) - ignoring"
 
     - if: steps.check-pr.outputs.has_prerelease_label == 'true'
       shell: bash
       run: |
         echo "Your PR number is ${{ steps.PR.outputs.number }}"
-        echo "contains: ${{ contains(toJSON(fromJSON(steps.PR.outputs.pr).labels.*.name), 'dog') }}"
-        echo "contains: ${{ contains(toJSON(fromJSON(steps.PR.outputs.pr).labels.*.name), 'prerelease') }}"
+        echo "::debug::labels.contains('prerelease'): ${{ contains(toJSON(fromJSON(steps.PR.outputs.pr).labels.*.name), 'prerelease') }}"
 
     # Compute next release
     - uses: open-turo/action-setup-tools@v1
@@ -105,17 +152,18 @@ runs:
 
     - name: Prerelease
       id: prerelease
-      uses: open-turo/actions-release/semantic-release@v3
+      uses: open-turo/actions-release/semantic-release@v4
       if: steps.check-pr.outputs.has_prerelease_label == 'true'
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
-        GITHUB_REF: ${{ github.head_ref }}
         ORG_GRADLE_PROJECT_artifactoryAuthToken: ${{ inputs.artifactory-auth-token }}
         ORG_GRADLE_PROJECT_artifactoryUsername: ${{ inputs.artifactory-username }}
       with:
-        branches: '["main", {"name": "${{ github.ref_name }}","channel": "next","prerelease": "pr-${{ steps.PR.outputs.number }}.${{ github.run_number }}.${{ github.run_attempt }}"}]'
+        branches: '["main", {"name": "${{ steps.source-vars.outputs.branch }}","channel": "next","prerelease": "pr-${{ steps.PR.outputs.number }}.${{ github.run_number }}.${{ github.run_attempt }}"}]'
         dry-run: ${{ inputs.create-prerelease == 'false' }}
         extra-plugins: ${{ inputs.extra-plugins }}
+        override-github-ref-name: ${{ steps.source-vars.outputs.branch }}
+        override-github-sha: ${{ steps.source-vars.outputs.sha }}  
 
     - id: vars
       if: steps.check-pr.outputs.has_prerelease_label == 'true'
@@ -138,6 +186,24 @@ runs:
           type=ref,event=branch
           type=ref,event=pr
           type=semver,pattern={{version}},value=${{ steps.vars.outputs.version }}
+
+    - name: Add new version to summary
+      shell: bash
+      if: steps.prerelease.outputs.new-release-published == 'true'
+      env:
+        NEW_VERSION: ${{ steps.vars.outputs.version }}
+        DOCKER_IMAGE: ${{ steps.build-docker.outputs.image-with-tag }}
+      run: |
+        echo "::notice::new version: \`${NEW_VERSION}\`"
+        echo "#### New version: \`${NEW_VERSION}\`" >> $GITHUB_STEP_SUMMARY
+        echo "#### Docekr image: \`${DOCKER_IMAGE}\`" >> $GITHUB_STEP_SUMMARY
+
+    - name: Add no new version to summary
+      shell: bash
+      if: steps.prerelease.outputs.new-release-published != 'true'
+      run: |
+        echo "::notice::no new version"
+        echo "### New version: 'NONE" >> $GITHUB_STEP_SUMMARY
 
     - name: Check for release notes comment
       uses: peter-evans/find-comment@v2

--- a/prerelease-msvc/action.yaml
+++ b/prerelease-msvc/action.yaml
@@ -71,13 +71,6 @@ runs:
         echo "$GITHUB_CONTEXT"
         echo "::endgroup::"
 
-    - name: Dump environment
-      shell: bash
-      run: |
-        echo "::group::bash_env"
-        set
-        echo "::endgroup::"
-
     - name: Set vars
       id: source-vars
       shell: bash

--- a/release/README.md
+++ b/release/README.md
@@ -1,8 +1,12 @@
 # GitHub Action Release
 
+<!-- prettier-ignore-start -->
+<!-- action-docs-description -->
 ## Description
 
 GitHub Action to publish a new release
+<!-- action-docs-description -->
+<!-- prettier-ignore-end -->
 
 ## Configuration
 
@@ -25,26 +29,37 @@ steps:
 **IMPORTANT**: `GITHUB_TOKEN` does not have the required permissions to operate on protected branches.
 If you are using this action for protected branches, replace `GITHUB_TOKEN` with [Personal Access Token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line). If using the `@semantic-release/git` plugin for protected branches, avoid persisting credentials as part of `actions/checkout@v4` by setting the parameter `persist-credentials: false`. This credential does not have the required permission to operate on protected branches.
 
+<!-- prettier-ignore-start -->
+<!-- action-docs-inputs -->
 ## Inputs
 
-| parameter     | description                                                                                                           | required | default |
-| ------------- | --------------------------------------------------------------------------------------------------------------------- | -------- | ------- |
-| checkout-repo | Perform checkout as first step of action                                                                              | `false`  | true    |
-| github-token  | GitHub token that can checkout the repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN' | `true`   |         |
-| dry-run       | Whether to run semantic release in `dry-run` mode. It will override the dryRun attribute in your configuration file   | `false`  | false   |
-| extra-plugins | Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.     | `false`  |         |
+| parameter | description | required | default |
+| --- | --- | --- | --- |
+| checkout-repo | Perform checkout as first step of action | `false` | true |
+| github-token | GitHub token that can checkout the repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN' | `true` |  |
+| dry-run | Whether to run semantic release in `dry-run` mode. It will override the dryRun attribute in your configuration file | `false` | false |
+| extra-plugins | Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.  Defaults to install @open-turo/semantic-release-config. | `false` | @open-turo/semantic-release-config@^1.4.0  |
+<!-- action-docs-inputs -->
 
+<!-- action-docs-outputs -->
 ## Outputs
 
-| parameter                 | description                         |
-| ------------------------- | ----------------------------------- |
-| new-release-published     | Whether a new release was published |
-| new-release-version       | Version of the new release          |
-| new-release-major-version | Major version of the new release    |
+| parameter | description |
+| --- | --- |
+| new-release-published | Whether a new release was published |
+| new-release-version | Version of the new release |
+| new-release-major-version | Major version of the new release |
+<!-- action-docs-outputs -->
 
+<!-- action-docs-runs -->
 ## Runs
 
-This action is an `composite` action.
+This action is a `composite` action.
+<!-- action-docs-runs -->
+
+<!-- action-docs-usage  -->
+<!-- action-docs-usage -->
+<!-- prettier-ignore-end -->
 
 ## Additional Examples
 

--- a/script/update-action-readme
+++ b/script/update-action-readme
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+
+for i in $*; do
+  # ignore if the file does not end with /action.yaml
+  if [[ "$i" != *"/action.yaml" ]]; then
+    echo "skipping: ${i}"
+    continue
+  fi
+  readme_file=$(dirname "$i")/README.md
+  echo "npx action-docs --no-banner -a "${i}" --update-readme "${readme_file}""
+  npx action-docs --no-banner -a "${i}" --update-readme "${readme_file}"
+done

--- a/test/README.md
+++ b/test/README.md
@@ -1,8 +1,12 @@
 # GitHub Action Test
 
+<!-- prettier-ignore-start -->
+<!-- action-docs-description -->
 ## Description
 
 GitHub Action that runs unit tests present within a JVM based (e.g. Java) GitHub repository and report test coverage metrics.
+<!-- action-docs-description -->
+<!-- prettier-ignore-end -->
 
 ## Usage
 
@@ -40,20 +44,33 @@ jobs:
           gradle-task: integrationTest
 ```
 
+<!-- prettier-ignore-start -->
+<!-- action-docs-inputs -->
 ## Inputs
 
-| parameter              | description                                                                     | required | default |
-| ---------------------- | ------------------------------------------------------------------------------- | -------- | ------- |
-| checkout-repo          | Perform checkout as first step of action                                        | `false`  | true    |
-| github-token           | GitHub token that can checkout the repository. e.g. 'secrets.GITHUB_TOKEN'      | `true`   |         |
-| artifactory-username   | Username to use for Artifactory access                                          | `true`   |         |
-| artifactory-auth-token | Authentication token to use with username for Artifactory access                | `true`   |         |
-| gradle-task            | An optional string for the gradle test task to run. e.g. "integrationTest"      | `false`  | `test`  |
-| gradlew-args           | An optional string of command line arguments to pass to gradlew. e.g. "--debug" | `false`  |         |
+| parameter | description | required | default |
+| --- | --- | --- | --- |
+| checkout-repo | Perform checkout as first step of action | `false` | true |
+| github-token | GitHub token that can checkout the repository. e.g. 'secrets.GITHUB_TOKEN' | `true` |  |
+| artifactory-username | Username to use for Artifactory access | `true` |  |
+| artifactory-auth-token | Authentication token to use with username for Artifactory access | `true` |  |
+| gradle-task | An optional string for the gradle test task to run. e.g. "integrationTest" | `false` | test |
+| gradlew-args | An optional string of command line arguments to pass to gradlew. e.g. "--debug" | `false` |  |
+<!-- action-docs-inputs -->
 
+<!-- action-docs-outputs -->
+
+<!-- action-docs-outputs -->
+
+<!-- action-docs-runs -->
 ## Runs
 
-This action is an `composite` action.
+This action is a `composite` action.
+<!-- action-docs-runs -->
+
+<!-- action-docs-usage  -->
+<!-- action-docs-usage -->
+<!-- prettier-ignore-end -->
 
 ## Test
 


### PR DESCRIPTION
**Description**

We have updated the actions-jvm to use open-turo/actions-release that supports working on pull request triggers.

This means that prerelease can run on pull request triggers.

It also means that we can include linting of release notes in our default lint action.

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
