### PR TITLE
feat: also pass credentials as build secrets

### DIFF
--- a/build-docker/action.yaml
+++ b/build-docker/action.yaml
@@ -99,3 +99,7 @@ runs:
         push: true
         tags: ${{ steps.config.outputs.image-name }}:${{ inputs.image-version }}
         labels: ${{ steps.meta.outputs.labels }}
+        secrets: |
+          ARTIFACTORY_USERNAME=${{ inputs.ARTIFACTORY_USERNAME }}
+          ARTIFACTORY_AUTH_TOKEN=${{ inputs.ARTIFACTORY_AUTH_TOKEN }}
+          GITHUB_TOKEN=${{ inputs.github-token }}


### PR DESCRIPTION
Per https://docs.docker.com/build/building/secrets/

> _Build arguments and environment variables are inappropriate for passing secrets to your build, because they persist in the final image. Instead, should use secret mounts or SSH mounts, which expose secrets to your builds securely._

As a migration step, this will pass tokens/keys as build secrets for secret while keeping the existing build-args until we can properly update Dockerfiles to use them.