### PR TITLE
Add support for setup script

### DIFF
--- a/test/action.yaml
+++ b/test/action.yaml
@@ -1,6 +1,12 @@
 name: jvm Test
 description: GitHub Action that runs unit tests present within a JVM based (e.g. Java) GitHub repository and report test coverage metrics.
 inputs:
+  artifactory-username:
+    required: true
+    description: Username to use for Artifactory access
+  artifactory-auth-token:
+    required: true
+    description: Authentication token to use with username for Artifactory access
   checkout-repo:
     required: false
     description: "Perform checkout as first step of action"
@@ -8,20 +14,15 @@ inputs:
   github-token:
     required: true
     description: GitHub token that can checkout the repository. e.g. 'secrets.GITHUB_TOKEN'
-  artifactory-username:
-    required: true
-    description: Username to use for Artifactory access
-  artifactory-auth-token:
-    required: true
-    description: Authentication token to use with username for Artifactory access
-  gradle-task:
-    required: false
-    description: An optional string for the gradle test task to run. e.g. "integrationTest"
-    default: "test"
   gradlew-args:
     required: false
     description: An optional string of command line arguments to pass to gradlew. e.g. "--debug"
     default: ""
+  gradle-task:
+    required: false
+    description: An optional string for the gradle test task to run. e.g. "integrationTest"
+    default: "test"
+
 runs:
   using: composite
   steps:

--- a/test/action.yaml
+++ b/test/action.yaml
@@ -35,11 +35,6 @@ runs:
       if: inputs.checkout-repo == 'true'
     - name: Setup tools
       uses: open-turo/action-setup-tools@v1
-    - name: Run setup script
-      if: inputs.setup-script != ''
-      shell: bash
-      run: |
-        ${{ inputs.setup-script }}
     - name: Test
       env:
         JAVA_HOME: ${{ env.JAVA_HOME }}
@@ -48,4 +43,7 @@ runs:
         sdk current
         sdk env
         sdk current
+        if [ -n "${{ inputs.setup-script }}" ]; then
+          ${{ inputs.setup-script }}
+        fi
         ./gradlew ${{ inputs.gradle-task }} -PartifactoryUsername=${{ inputs.artifactory-username }} -PartifactoryAuthToken=${{ inputs.artifactory-auth-token }} ${{ inputs.gradlew-args }}

--- a/test/action.yaml
+++ b/test/action.yaml
@@ -22,6 +22,10 @@ inputs:
     required: false
     description: An optional string for the gradle test task to run. e.g. "integrationTest"
     default: "test"
+  setup-script:
+    required: false
+    description: Script to run before tests
+    default: ""
 
 runs:
   using: composite
@@ -31,6 +35,11 @@ runs:
       if: inputs.checkout-repo == 'true'
     - name: Setup tools
       uses: open-turo/action-setup-tools@v1
+    - name: Run setup script
+      if: inputs.setup-script != ''
+      shell: bash
+      run: |
+        ${{ inputs.setup-script }}
     - name: Test
       env:
         JAVA_HOME: ${{ env.JAVA_HOME }}


### PR DESCRIPTION
Add the ability to run a setup script before running the test. We need this specifically to run jobs that are not java-based (for java-specific project might be a better way should probably be a way)