### PR TITLE
feat: update to actions-release@v5

### DIFF
--- a/lint/action.yaml
+++ b/lint/action.yaml
@@ -27,7 +27,7 @@ runs:
       env:
         ORG_GRADLE_PROJECT_artifactoryUsername: ${{ inputs.artifactory-username }}
         ORG_GRADLE_PROJECT_artifactoryAuthToken: ${{ inputs.artifactory-auth-token }}
-    - uses: open-turo/actions-release/lint-release-notes@v4
+    - uses: open-turo/actions-release/lint-release-notes@v5
       if: github.event_name == 'pull_request'
       with:
         github-token: ${{ inputs.github-token }}

--- a/prerelease-msvc/action.yaml
+++ b/prerelease-msvc/action.yaml
@@ -147,7 +147,7 @@ runs:
 
     - name: Prerelease
       id: prerelease
-      uses: open-turo/actions-release/semantic-release@v4
+      uses: open-turo/actions-release/semantic-release@v5
       if: steps.check-pr.outputs.has_prerelease_label == 'true'
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}

--- a/release/action.yaml
+++ b/release/action.yaml
@@ -57,7 +57,7 @@ runs:
         fi
     - name: Release
       id: release
-      uses: open-turo/actions-release/semantic-release@v4
+      uses: open-turo/actions-release/semantic-release@v5
       with:
         branches: ${{ steps.branches-configuration.outputs.branches }}
         dry-run: ${{ inputs.dry-run }}


### PR DESCRIPTION
**Description**

Update actions-release to v5. This failed on several repos on the first attempt, but after shipping https://github.com/open-turo/actions-release/pull/83 it's now working in some of our internal repos.

**Changes**

* feat: update to actions-release@v5

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
