### PR TITLE
DEVOPS-12455: Pin version to fix CI for linux/arm64 docker build

### DIFF
--- a/build-docker/action.yaml
+++ b/build-docker/action.yaml
@@ -80,6 +80,10 @@ runs:
         echo "docker-metadata-tags: ${{ inputs.docker-metadata-tags }}"
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
+      with:
+        platforms: ${{ inputs.image-platform }}
+        # The latest version will lead to segmentation fault. Ref: https://github.com/docker/setup-qemu-action/issues/201
+        image: tonistiigi/binfmt:qemu-v7.0.0-28
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
     - name: Login to Docker Hub


### PR DESCRIPTION
**Description**
Pin version to fix CI for linux/arm64 docker build.

It’s a known bug from qemu. Pin it to tonistiigi/binfmt:qemu-v7.0.0-28 as suggested in
https://github.com/docker/setup-qemu-action/issues/201 , until the latest version has resolved it.

Multiple msvc repos have recently experienced the same error:
![image](https://github.com/user-attachments/assets/986e8000-29e7-4cf0-94c4-6be9e1d3273c)


Related Discussion:
https://team-turo.slack.com/archives/C01BN39LHLH/p1740010908076559 

Fixes [#DEVOPS-12455](https://team-turo.atlassian.net//browse/DEVOPS-12455)

**Changes**

* fix(ci): pin version to qemu-v7.0.0-28

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
