### PR TITLE
DEVX-81: fix action-setup-tools issue with actions-jvm 

### DIFF
--- a/lint/action.yaml
+++ b/lint/action.yaml
@@ -22,6 +22,9 @@ runs:
       if: inputs.checkout-repo == 'true'
       with:
         fetch-depth: 0
+    - name: Setup tools
+      # Provide opportunity to install terraform, golang, and others
+      uses: open-turo/action-setup-tools@v3
     - name: Pre-commit
       uses: open-turo/action-pre-commit@v3
       env:


### PR DESCRIPTION

**Description**
add action-setup-tools step to make sure java is installed


Fixes [#DEVX-81](https://team-turo.atlassian.net//browse/DEVX-81)

**Changes**

* chore(deps): update open-turo/actions-jvm action to v2

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
