### PR TITLE
fix(lint): use correct artifactory username when running lint-release-notes

### DIFF
--- a/lint/action.yaml
+++ b/lint/action.yaml
@@ -36,5 +36,5 @@ runs:
         github-token: ${{ inputs.github-token }}
         checkout-repo: true
       env:
-        ORG_GRADLE_PROJECT_artifactoryUsername: ${{ inputs.artifactory-auth-token }}
+        ORG_GRADLE_PROJECT_artifactoryUsername: ${{ inputs.artifactory-username }}
         ORG_GRADLE_PROJECT_artifactoryAuthToken: ${{ inputs.artifactory-auth-token }}


### PR DESCRIPTION
Fixing a typo causing failure to authenticate to the artifactory