### PR TITLE
DEVX-200: remove sdkman from actions-jvm

### DIFF
--- a/test/action.yaml
+++ b/test/action.yaml
@@ -35,7 +35,4 @@ runs:
         JAVA_HOME: ${{ env.JAVA_HOME }}
       shell: bash
       run: |
-        sdk current
-        sdk env
-        sdk current
         ./gradlew ${{ inputs.gradle-task }} -PartifactoryUsername=${{ inputs.artifactory-username }} -PartifactoryAuthToken=${{ inputs.artifactory-auth-token }} ${{ inputs.gradlew-args }}


### PR DESCRIPTION
**Description**
remove sdkman command, since we are using setup-java(in action-setup-tools@v3) that install java version on the fly now

This will fix err related to the sdkman command as well
```
Run sdk current
/home/runner/_work/_temp/1b808e8b-b3d5-420c-bb9a-10e3303a1b23.sh: line 1: sdk: command not found
```


**Changes**

* fix: remove sdkman command

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
