### PR TITLE
fix(lint): adds github token to pre-commit for private repos

### DIFF
--- a/lint/action.yaml
+++ b/lint/action.yaml
@@ -27,6 +27,8 @@ runs:
       uses: open-turo/action-setup-tools@v3
     - name: Pre-commit
       uses: open-turo/action-pre-commit@v3
+      with:
+        github-token: ${{ inputs.github-token }}
       env:
         ORG_GRADLE_PROJECT_artifactoryUsername: ${{ inputs.artifactory-username }}
         ORG_GRADLE_PROJECT_artifactoryAuthToken: ${{ inputs.artifactory-auth-token }}


### PR DESCRIPTION
**Description**

Passes github-token through to the pre-commit action to allow for fetching pre-commit hooks from private repos.



**Changes**

* fix(lint): adds github token to pre-commit for private repos

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
