### PR TITLE
DEVEX-11: Support multi platform builds on open-turo jvm actions

### DIFF
--- a/build-docker/README.md
+++ b/build-docker/README.md
@@ -52,6 +52,33 @@ steps:
         type=semver,pattern={{version}},value=${{ steps.release.outputs.new-release-version }}
 ```
 
+#### Multi-Platform Build:
+
+```yaml
+steps:
+  - uses: open-turo/actions-jvm/release@v3
+    name: Release
+    id: release
+    with:
+      checkout-repo: true
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+      dry-run: false
+  - uses: open-turo/actions-jvm/build-docker@v1
+    id: docker-build
+    with:
+      dockerhub-user: ${{ secrets.DOCKER_USERNAME }}
+      dockerhub-password: ${{ secrets.DOCKER_PASSWORD }}
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+      artifactory-username: ${{ secrets.ARTIFACTORY_USERNAME }}
+      artifactory-auth-token: ${{ secrets.ARTIFACTORY_AUTH_TOKEN }}
+      image-version: ${{ steps.release.outputs.new-release-version }}
+      image-platform: linux/amd64,linux/arm64
+      docker-metadata-tags: |
+        type=ref,event=branch
+        type=ref,event=pr
+        type=semver,pattern={{version}},value=${{ steps.release.outputs.new-release-version }}
+```
+
 #### Dynamically input multiple build arguments and secrets:
 
 If you want to pass multiple build arguments and secrets, you can use the `build-args` and `secrets` input parameters.
@@ -102,7 +129,7 @@ If you are using this action for protected branches, replace `GITHUB_TOKEN` with
 | artifactory-username | Artifactory user name usually secrets.ARTIFACTORY_USERNAME | `true` |  |
 | artifactory-auth-token | Artifactory auth token usually secrets.ARTIFACTORY_AUTH_TOKEN | `true` |  |
 | image-version | Docker image version | `true` |  |
-| image-platform | Target platform to build image for (eg. linux/amd64 (default), linux/arm64, etc) | `false` | linux/amd64 |
+| image-platform | Target platform(s) to build image for (eg. linux/amd64 for single platform, or linux/amd64,linux/arm64 for multi-platform) | `false` | linux/amd64 |
 | docker-metadata-tags | 'List of tags as key-value pair attributes' See: https://github.com/docker/metadata-action#tags-input | `false` |  |
 | push | Do you want to push the image to the registry | `false` | true |
 | load | Do you want to load the single-platform build result to docker images | `false` | false |

--- a/build-docker/action.yaml
+++ b/build-docker/action.yaml
@@ -24,7 +24,7 @@ inputs:
     required: true
     description: Docker image version
   image-platform:
-    description: Target platform to build image for (eg. linux/amd64 (default), linux/arm64, etc)
+    description: Target platform(s) to build image for (eg. linux/amd64 for single platform, or linux/amd64,linux/arm64 for multi-platform)
     required: false
     default: linux/amd64
   docker-metadata-tags:

--- a/prerelease-msvc/README.md
+++ b/prerelease-msvc/README.md
@@ -18,12 +18,33 @@
 
 ## Usage
 
+### Basic Usage
+
 ```yaml
 steps:
   - name: Action semantic release
     uses: open-turo/actions-jvm/prerelease-msvc@v1
     with:
       github-token: ${{ secrets.GITHUB_TOKEN }}
+      dockerhub-user: ${{ secrets.DOCKER_USERNAME }}
+      dockerhub-password: ${{ secrets.DOCKER_PASSWORD }}
+      artifactory-username: ${{ secrets.ARTIFACTORY_USERNAME }}
+      artifactory-auth-token: ${{ secrets.ARTIFACTORY_AUTH_TOKEN }}
+```
+
+### Multi-Platform Build
+
+```yaml
+steps:
+  - name: Action semantic release
+    uses: open-turo/actions-jvm/prerelease-msvc@v1
+    with:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+      dockerhub-user: ${{ secrets.DOCKER_USERNAME }}
+      dockerhub-password: ${{ secrets.DOCKER_PASSWORD }}
+      artifactory-username: ${{ secrets.ARTIFACTORY_USERNAME }}
+      artifactory-auth-token: ${{ secrets.ARTIFACTORY_AUTH_TOKEN }}
+      image-platform: linux/amd64,linux/arm64
 ```
 
 **IMPORTANT**: `GITHUB_TOKEN` does not have the required permissions to operate on protected branches.
@@ -48,6 +69,7 @@ required permission to operate on protected branches.
 | extra-plugins | Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.  Defaults to install @open-turo/semantic-release-config. | `false` | @open-turo/semantic-release-config  |
 | artifactory-username | Artifactory user name usually secrets.ARTIFACTORY_USERNAME | `true` |  |
 | artifactory-auth-token | Artifactory auth token usually secrets.ARTIFACTORY_AUTH_TOKEN | `true` |  |
+| image-platform | Target platform(s) to build image for (eg. linux/amd64 for single platform, or linux/amd64,linux/arm64 for multi-platform) | `false` | linux/amd64 |
 <!-- action-docs-inputs -->
 
 <!-- action-docs-outputs -->

--- a/prerelease-msvc/action.yaml
+++ b/prerelease-msvc/action.yaml
@@ -36,6 +36,10 @@ inputs:
   github-token:
     required: true
     description: GitHub token that can checkout the repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN'
+  image-platform:
+    description: Target platform(s) to build image for (eg. linux/amd64 for single platform, or linux/amd64,linux/arm64 for multi-platform)
+    required: false
+    default: linux/amd64
 
 outputs:
   new-release-published:
@@ -177,6 +181,7 @@ runs:
         artifactory-username: ${{ inputs.artifactory-username }}
         artifactory-auth-token: ${{ inputs.artifactory-auth-token }}
         image-version: ${{ steps.vars.outputs.version }}
+        image-platform: ${{ inputs.image-platform }}
         docker-metadata-tags: |
           type=ref,event=branch
           type=ref,event=pr


### PR DESCRIPTION

**Description**

Update pre-release to specify build platforms. The build-docker action has an image-platform field which can support a list, reuse it rather than having to release a new breaking version for multi platform builds.

Fixes [#DEVEX-11](https://team-turo.atlassian.net//browse/DEVEX-11)

**Changes**

* feat: support specifying build platforms for pre-release

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
