### PR TITLE
fix: use open turo action for posting prerelease comments

### DIFF
--- a/prerelease-msvc/action.yaml
+++ b/prerelease-msvc/action.yaml
@@ -205,28 +205,14 @@ runs:
         echo "::notice::no new version"
         echo "### New version: 'NONE" >> $GITHUB_STEP_SUMMARY
 
-    - name: Check for release notes comment
-      uses: peter-evans/find-comment@v3
-      id: fc-prerelease
+    - name: Post status comment
+      uses: open-turo/action-conditional-pr-comment@v1
       if: steps.prerelease.outputs.new-release-published == 'true'
       with:
-        issue-number: ${{ steps.PR.outputs.number }}
-        comment-author: "github-actions[bot]"
-        body-includes: "<!-- prerelease comment -->"
-    - name: Delete previous release note
-      if: steps.fc-prerelease.outputs.comment-id != ''
-      uses: winterjung/comment@v1
-      with:
-        type: delete
-        comment_id: ${{ steps.fc-prerelease.outputs.comment-id }}
-        token: ${{ inputs.github-token }}
-
-    - name: Upsert build version
-      if: steps.prerelease.outputs.new-release-published == 'true'
-      uses: peter-evans/create-or-update-comment@v4
-      with:
-        issue-number: ${{ steps.PR.outputs.number }}
-        body: |
+        workflow: ADD
+        text-detector: "prerelease comment"
+        edit-mode: replace
+        comment: |
           <!-- prerelease comment -->
           ## Prerelease build
 
@@ -234,3 +220,5 @@ runs:
           **Docker image:** `${{ steps.build-docker.outputs.image-with-tag }}`
 
           [Build output](${{ steps.vars.outputs.run-url }})
+        comment-author: "github-actions[bot]"
+        github-token: ${{ inputs.github-token }}

--- a/prerelease/action.yaml
+++ b/prerelease/action.yaml
@@ -166,31 +166,19 @@ runs:
         echo "::notice::no new version"
         echo "### New version: 'NONE" >> $GITHUB_STEP_SUMMARY
 
-    - name: Check for release notes comment
-      uses: peter-evans/find-comment@v3
-      id: fc-prerelease
+    - name: Post status comment
+      uses: open-turo/action-conditional-pr-comment@v1
       if: steps.prerelease.outputs.new-release-published == 'true'
       with:
-        issue-number: ${{ steps.PR.outputs.number }}
-        comment-author: "github-actions[bot]"
-        body-includes: "<!-- prerelease comment -->"
-    - name: Delete previous release note
-      if: steps.fc-prerelease.outputs.comment-id != ''
-      uses: winterjung/comment@v1
-      with:
-        type: delete
-        comment_id: ${{ steps.fc-prerelease.outputs.comment-id }}
-        token: ${{ inputs.github-token }}
-
-    - name: Upsert build version
-      if: steps.prerelease.outputs.new-release-published == 'true'
-      uses: peter-evans/create-or-update-comment@v4
-      with:
-        issue-number: ${{ steps.PR.outputs.number }}
-        body: |
+        workflow: ADD
+        text-detector: "prerelease comment"
+        edit-mode: replace
+        comment: |
           <!-- prerelease comment -->
           ## Prerelease build
 
           **Build version:** `${{ steps.vars.outputs.version }}`
 
           [Build output](${{ steps.vars.outputs.run-url }})
+        comment-author: "github-actions[bot]"
+        github-token: ${{ inputs.github-token }}


### PR DESCRIPTION

**Description**

This is a simpler action which is also simpler to use and also works in arm64 runners since it doesn't need to run on a docker image (the current one only has an amd64 image)

**Changes**

* fix: use open turo action for posting prerelease comments

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
